### PR TITLE
Refactor create dir if not exists approach (Resolves #10)

### DIFF
--- a/normalization/FS_general_formatter.py
+++ b/normalization/FS_general_formatter.py
@@ -168,17 +168,11 @@ if len(sys.argv) > 1:
             for path_item in path:
                 if ".cha" not in path_item:
                     path_list.append(path_item)
-            #print("\\".join(path_list))
-            path = "recoded\\" + "\\".join(path_list)
-            #print(path)
 
-            
-            
-            if not os.path.exists(path):
-                os.makedirs(path)
-
-
-                
+            output_directory = os.path.dirname(file_path)
+            if not os.path.exists(output_directory):
+                os.makedirs(output_directory)
+      
             writing_file = open(file_path, "w", encoding="utf8")
             writing_file.write(prepared_string)
             writing_file.close()


### PR DESCRIPTION
This involves minor refactoring of a 'create directory if not exists' approach that seemed to be problematic in `FS_general_formatter.py`. See explanation at https://github.com/writecrow/text_processing/issues/10

If there was some reason the script *was* done the way it is, do let me know & I can close this.

### Testing Steps
0. `cd normalization`
1. `FS_general_formatter.py test-data/sample.cha`
2. Verify a `recoded/test-data` directory is created, with a `sample.txt` file with expected output.