### PR TITLE
Properly define encoding to use in open() method for Windows machines…

### DIFF
--- a/gpio/gpio.py
+++ b/gpio/gpio.py
@@ -43,7 +43,7 @@ def process_file(filename, overwrite=False):
         if not os.path.exists(output_directory):
             os.makedirs(output_directory)
 
-    infile = open(filename, 'r').read()
+    infile = open(filename, 'r', encoding="utf-8").read()
     # Here, the text is passed to the process() function.
     # @see process_script.py
     processed = process(infile)

--- a/normalization/textnormalization.py
+++ b/normalization/textnormalization.py
@@ -15,7 +15,7 @@ printable = set(string.printable)
 if __name__ == '__main__':
     if len(sys.argv) > 1:
         for file in sys.argv[1:]:
-            with open(file, 'r') as f:
+            with open(file, 'r', encoding="utf-8") as f:
                 try:
                     output_dir = 'cleaned'
                     file_name = os.path.basename(f.name)

--- a/normalization/textnormalization.py
+++ b/normalization/textnormalization.py
@@ -15,7 +15,7 @@ printable = set(string.printable)
 if __name__ == '__main__':
     if len(sys.argv) > 1:
         for file in sys.argv[1:]:
-            with open(file, 'r', encoding="utf-8") as f:
+            with codecs.open (file, 'r', encoding = 'utf8') as f:
                 try:
                     output_dir = 'cleaned'
                     file_name = os.path.basename(f.name)


### PR DESCRIPTION
## Problem
When the `textnormalization.py` script was being run on Windows machines, an error was being produced and the script was failing:

```
<class 'UnicodeDecodeError'>	'ascii' codec can't decode byte 0xe2 in position 2089: ordinal not in range(128)
```

## Cause
A couple of our scripts which use the `open()` method were not defining what encoding format should be used; on *Nix like machines (e.g., Mac), the encoding format defaults to `utf-8`, so there was no issue. On Windows machines, this was defaulting to `windows-1251`. See https://stackoverflow.com/a/35444608 and http://python-notes.curiousefficiency.org/en/latest/python3/text_file_processing.html#files-in-an-ascii-compatible-encoding-best-effort-is-acceptable

## Solution
Explicitly tell the `open()` method to use `utf-8` encoding.

## Testing Steps
0. Check out this branch (or just [download this branch's version](https://raw.githubusercontent.com/writecrow/text_processing/d44e2403d62023e3a39dee2223bdaef0f46c56a0/normalization/textnormalization.py) of the textnormalization.py script)
1. Run the `textnormalization.py` script against a sample .txt file and verify that the script no longer throws the unicode decode error, and that the file is properly normalized (it will be placed in the `cleaned` directory).